### PR TITLE
Misc Issues PR

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,24 +1,41 @@
 <p align="center">
-<img src="https://raw.githubusercontent.com/ai4er-cdt/gtc-biodiversity/main/docs/images/geograph_logo.png" alt="GeoGraph" width="300px">
+<img src="https://raw.githubusercontent.com/ai4er-cdt/geograph/main/docs/images/geograph_logo.png" alt="GeoGraph" width="300px">
 </p>
 
-_Created as part of the AI4ER Group Team Challenge 2021 by the Biodiversity Team._
-
-
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ai4er-cdt/gtc-biodiversity/main?urlpath=lab%2Ftree%2Fnotebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ai4er-cdt/geograph/main?urlpath=lab%2Ftree%2Fnotebooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Documentation Status](https://readthedocs.org/projects/geograph/badge/?version=latest)](https://geograph.readthedocs.io/en/latest/?badge=latest)
 
-See the [Github repository](https://github.com/ai4er-cdt/gtc-biodiversity) for full details.
 
-## 1. Features
+__Table of contents:__
+1. Description
+2. Installation
+3. Requirements
+4. Documentation
 
-GeoGraph provides a full-stack tool for analysing habitat fragmentation, and other related problems. It includes models to predict land cover classes, a method to extract graph structure from the resulting land cover maps and an extensive range of visualisation and analysis tools.
+## 1. Description
 
-## 2. Requirements
+GeoGraph provides a tool for analysing habitat fragmentation, related problems in landscape ecology. GeoGraph builds a geospatially referenced graph from land cover or field survey data and enables graph-based landscape ecology analysis as well as interactive visualizations. Beyond the graph-based features, GeoGraph also enables the computation of common landscape metrics.
 
-GeoGraph is written in Python 3.8 and builds on [NetworkX](https://github.com/NetworkX/NetworkX), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) and many more packages. See the [requirements directory](https://github.com/ai4er-cdt/gtc-biodiversity/tree/main/requirements) for a full list of dependencies.
-## 3. Documentation
+## 2. Installation
+
+GeoGraph is available via pip, so you can install it using
+
+```
+pip install geograph
+```
+
+Done, you're ready to go!
+
+You can also visit the [Github repository](https://github.com/ai4er-cdt/geograph).
+
+See the [documentation](https://geograph.readthedocs.io/) for a full getting started guide.
+
+## 3. Requirements
+
+GeoGraph is written in Python 3.8 and builds on [NetworkX](https://github.com/NetworkX/NetworkX), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) and many more packages. See the [requirements directory](./requirements) for a full list of dependencies.
+
+## 4. Documentation
 
 Our documentation is available at [geograph.readthedocs.io](https://geograph.readthedocs.io/).

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -16,7 +16,7 @@ __Table of contents:__
 
 ## 1. Description
 
-GeoGraph provides a tool for analysing habitat fragmentation, related problems in landscape ecology. GeoGraph builds a geospatially referenced graph from land cover or field survey data and enables graph-based landscape ecology analysis as well as interactive visualizations. Beyond the graph-based features, GeoGraph also enables the computation of common landscape metrics.
+GeoGraph provides a tool for analysing habitat fragmentation and related problems in landscape ecology. GeoGraph builds a geospatially referenced graph from land cover or field survey data and enables graph-based landscape ecology analysis as well as interactive visualizations. Beyond the graph-based features, GeoGraph also enables the computation of common landscape metrics.
 
 ## 2. Installation
 
@@ -30,11 +30,11 @@ Done, you're ready to go!
 
 You can also visit the [Github repository](https://github.com/ai4er-cdt/geograph).
 
-See the [documentation](https://geograph.readthedocs.io/) for a full getting started guide.
+See the [documentation](https://geograph.readthedocs.io/) for a full getting started guide or check out the [binder](https://mybinder.org/v2/gh/ai4er-cdt/geograph/main?urlpath=lab%2Ftree%2Fnotebooks) for tutorials on how to get started .
 
 ## 3. Requirements
 
-GeoGraph is written in Python 3.8 and builds on [NetworkX](https://github.com/NetworkX/NetworkX), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) and many more packages. See the [requirements directory](./requirements) for a full list of dependencies.
+GeoGraph is written in Python 3.8 and builds on [NetworkX](https://github.com/NetworkX/NetworkX), [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet), [geopandas](https://geopandas.org/), [rasterio](https://rasterio.readthedocs.io/en/latest/) and many more packages. See the [requirements directory](./requirements) for a full list of dependencies.
 
 ## 4. Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ai4er-cdt/gtc-biodiversity/main?urlpath=lab%2Ftree%2Fnotebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ai4er-cdt/geograph/main?urlpath=lab%2Ftree%2Fnotebooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Documentation Status](https://readthedocs.org/projects/geograph/badge/?version=latest)](https://geograph.readthedocs.io/en/latest/?badge=latest)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 [![Documentation Status](https://readthedocs.org/projects/geograph/badge/?version=latest)](https://geograph.readthedocs.io/en/latest/?badge=latest)
+[![PyPI version](https://badge.fury.io/py/geograph.svg)](https://badge.fury.io/py/geograph)
 
 ![GeoGraphViewer demo gif](docs/images/viewer_demo.gif)
 

--- a/geograph/binary_graph_operations.py
+++ b/geograph/binary_graph_operations.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class NodeMap:
-    """Class to store node mappings between two graphs (the src_graph and trg_graph)"""
+    """Class to store node mappings between two graphs (the src_graph and trg_graph)."""
 
     def __init__(
         self,
@@ -24,7 +24,7 @@ class NodeMap:
         mapping: Dict[int, List[int]],
     ) -> None:
         """
-        Class to store node mappings between two graphs (`trg_graph` and `src_graph`)
+        Class to store node mappings between two graphs (`trg_graph` and `src_graph`).
 
         This class stores a dictionary of node one-to-many relationships of nodes from
         `src_graph` to `trg_graph`. It also provides support for convenient methods for
@@ -45,27 +45,27 @@ class NodeMap:
 
     @property
     def src_graph(self) -> geograph.GeoGraph:
-        """Keys in the mapping dict correspond to node indices in the `src_graph`"""
+        """Keys in the mapping dict correspond to node indices in the `src_graph`."""
         return self._src_graph
 
     @property
     def trg_graph(self) -> geograph.GeoGraph:
-        """Values in the mapping dict correspond to node indices in the `trg_graph`"""
+        """Values in the mapping dict correspond to node indices in the `trg_graph`."""
         return self._trg_graph
 
     @property
     def mapping(self) -> Dict[int, List[int]]:
-        """
-        Look-up table connecting node indices from `src_graph` to those of `trg_graph`.
-        """
+        """Look-up table connecting node indices from `src_graph` to `trg_graph`."""
         return self._mapping
 
     def __invert__(self) -> NodeMap:
-        """Compute the inverse NodeMap"""
+        """Compute the inverse NodeMap."""
         return self.invert()
 
-    def __eq__(self, other: NodeMap) -> bool:
-        """Check two NodeMaps for equality"""
+    def __eq__(self, other: object) -> bool:
+        """Check two NodeMaps for equality."""
+        if not isinstance(other, NodeMap):
+            return False
         return (
             self.src_graph == other.src_graph
             and self.trg_graph == other.trg_graph
@@ -73,8 +73,8 @@ class NodeMap:
         )
 
     def invert(self) -> NodeMap:
-        """Compute the inverse NodeMap from `trg_graph` to `src_graph`"""
-        inverted_mapping = {index: [] for index in self.trg_graph.df.index}
+        """Compute the inverse NodeMap from `trg_graph` to `src_graph`."""
+        inverted_mapping: Dict = {index: [] for index in self.trg_graph.df.index}
 
         for src_node in self.src_graph.df.index:
             for trg_node in self.mapping[src_node]:
@@ -117,7 +117,7 @@ def identify_graphs(
     graph1: geograph.GeoGraph, graph2: geograph.GeoGraph, mode: str
 ) -> NodeMap:
     """
-    Idenitfy all nodes from `graph1` with nodes from `graph2` based on the given `mode`
+    Idenitfy all nodes from `graph1` with nodes from `graph2` based on the given `mode`.
 
     Args:
         graph1 (GeoGraph): The GeoGraph whose node indicies will form the domain
@@ -143,8 +143,7 @@ def identify_graphs(
 
 def graph_polygon_diff(node_map: NodeMap) -> Tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
-    Return the (multi)polygon areas that were added/removed when going
-    from `src_graph` to `trg_graph`.
+    Return the polygons that were added/removed going from `src_graph` to `trg_graph`.
 
     Args:
         node_map (NodeMap): The node map from `src_graph` to `trg_graph`
@@ -193,7 +192,6 @@ def node_polygon_diff(
         Tuple[BaseGeometry, BaseGeometry]: Added part and removed part as shapely
             BaseGeometry objects.
     """
-
     src_polygon: Polygon = node_map.src_graph.df.geometry.loc[src_node_id]
     trg_node_ids: List[int] = node_map.mapping[src_node_id]
 

--- a/geograph/constants.py
+++ b/geograph/constants.py
@@ -1,8 +1,4 @@
-"""
-This file is used to save all project wide constants such as the path of the
-source folder, the project path, etc.
-"""
-
+"""All project wide constants are saved in this module."""
 # Place all your constants here
 import os
 import pathlib

--- a/geograph/geograph.py
+++ b/geograph/geograph.py
@@ -729,7 +729,7 @@ class GeoGraph:
         Args:
             func (Callable): A function that is a method of GeoGraph or
                 HabitatGeoGraph. This must not be a method of an instance of
-            GeoGraph; it can only be an actual method definition, such as
+                GeoGraph; it can only be an actual method definition, such as
                 `GeoGraph.merge_nodes`.
 
         Raises:
@@ -935,13 +935,13 @@ class GeoGraph:
         adjacencies: Iterable[int],
         requires_sorting: bool = True,
         **data,
-    ):
+    ) -> None:
         """
         Add node to graph.
 
         Args:
             node_id (int): The id of the node to add.
-                adjacencies (Iterable[int]): Iterable of node ids which are adjacent
+            adjacencies (Iterable[int]): Iterable of node ids which are adjacent
                 to the new node.
             requires_sorting (bool, optional): Whether or not to sort the dataframe
                 index after adding the node. Defaults to True.
@@ -974,8 +974,32 @@ class GeoGraph:
         )
 
     # pylint: disable=dangerous-default-value
-    def _add_nodes(self, node_ids, adjacencies, node_data={}, **data):
-        raise NotImplementedError
+    def _add_nodes(
+        self,
+        node_ids,
+        adjacencies: Dict[int, Iterable[int]],
+        node_data: Dict[int, Dict],
+        requires_sorting: bool = True,
+    ) -> None:
+        """
+        Add multiple nodes to the graph.
+
+        Args:
+            node_ids (Iterable[int]): The ids of the nodes to add.
+            adjacencies (Dict[int, Iterable[int]): Dict mapping node ids to
+                Iterables of node ids which are adjacent to each new node.
+            node_data (Dict[int, Dict]): Dict mapping node ids to dictionaries of
+                node attributes.
+            requires_sorting (bool, optional): Whether or not to sort the dataframe
+                index after adding the nodes. Defaults to True.
+        """
+        for node_id in node_ids:
+            self._add_node(
+                node_id=node_id,
+                adjacencies=adjacencies[node_id],
+                requires_sorting=requires_sorting,
+                **node_data[node_id],
+            )
 
     def _merge_graph(self, other: GeoGraph) -> GeoGraph:
 

--- a/geograph/geograph.py
+++ b/geograph/geograph.py
@@ -570,9 +570,10 @@ class GeoGraph:
         own HabitatGeoGraph object with all meta information.
 
         The optional argument `barrier_classes` allows for a list of class labels
-        which block the path between two nodes in `valid_classes`. The pathfinding
-        code will not add an edge between them if the barrier class node in the
-        middle *completely* blocks the path, which is rare.
+        which block the path between two nodes in `valid_classes`. Warning: The current pathfinding
+        code is experimental and will only remove an edge between two classes within the max travel distance
+        if the barrier class node in the middle *completely* blocks the path, which is rare. A full version
+        of a pathfinding code is currently under development and will become available in a later release.
 
         Warning: In a large dataset, passing values to `barrier_classes` will often
         make this function significantly slower, up to an order of magnitude.
@@ -798,7 +799,7 @@ class GeoGraph:
         return comp_geograph
 
     def get_metric(
-        self, name: str, class_value: Union[int, str] = None, **metric_kwargs
+        self, name: str, class_value: Optional[Union[int, str]] = None, **metric_kwargs
     ) -> metrics.Metric:
         """
         Calculate and save the metric with name `name` for the current GeoGraph.
@@ -993,7 +994,7 @@ class GeoGraph:
             requires_sorting (bool, optional): Whether or not to sort the dataframe
                 index after adding the nodes. Defaults to True.
         """
-        for node_id in node_ids:
+        for node_id in node_ids:  # TODO: Speed up by turning into bulk operation
             self._add_node(
                 node_id=node_id,
                 adjacencies=adjacencies[node_id],

--- a/geograph/geograph.py
+++ b/geograph/geograph.py
@@ -677,10 +677,13 @@ class GeoGraph:
                         # barrier polygon. If this results in multiple polygons,
                         # then the barrier polygon fully cuts the buffered polygon.
                         #
-                        # Therefore we find the largest polygon in the result,
-                        # which will contain the original node polygon, and check
-                        # if it intersects the neighbour polygon we're trying to
-                        # reach. If it does not, there is no path.
+                        # We find the resulting buffered polygon fragment that contains 
+                        # the original node polygon, by selecting the polygon that 
+                        # contains a representative point sampled from the original 
+                        # polygon. 
+                        # We then check if that polygon fragment intersects the 
+                        # neighbour polygon we're trying to reach. 
+                        # If it does not, there is no path.
                         # If it does, there may be a path or there may not - it
                         # would require complex pathfinding code to discover, but
                         # we add the edge anyway.

--- a/geograph/metrics.py
+++ b/geograph/metrics.py
@@ -499,7 +499,7 @@ STANDARD_METRICS = ["num_components", "avg_patch_area", "total_area"]
 def _get_metric(
     name: str,
     geo_graph: geograph.GeoGraph,
-    class_value: Union[int, str] = None,
+    class_value: Optional[Union[int, str]] = None,
     **metric_kwargs,
 ) -> Metric:
     """

--- a/geograph/metrics.py
+++ b/geograph/metrics.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import networkx as nx
 import numpy as np
@@ -50,7 +50,7 @@ class Metric:
 
 
 ########################################################################################
-###### 1. Landscape level metrics
+# 1. Landscape level metrics
 ########################################################################################
 def _num_patches(geo_graph: geograph.GeoGraph) -> Metric:
     return Metric(
@@ -112,7 +112,7 @@ def _largest_patch_index(geo_graph: geograph.GeoGraph) -> Metric:
 
 def _shannon_diversity_index(geo_graph: geograph.GeoGraph) -> Metric:
     """
-    Calculate shannon diversity of GeoGraph
+    Calculate Shannon diversity of a GeoGraph.
 
     Further reference:
         https://pylandstats.readthedocs.io/en/latest/landscape.html
@@ -144,12 +144,11 @@ def _shannon_diversity_index(geo_graph: geograph.GeoGraph) -> Metric:
 
 def _simpson_diversity_index(geo_graph: geograph.GeoGraph) -> Metric:
     """
-    Calculate simpson diversity of GeoGraph
+    Calculate Simpson diversity of a GeoGraph.
 
     Reference:
         umass.edu/landeco/teaching/landscape_ecology/schedule/chapter9_metrics.pdf
     """
-
     class_prop_of_landscape = np.array(
         [
             geo_graph.get_metric(
@@ -184,11 +183,13 @@ LANDSCAPE_METRICS_DICT = {
 }
 
 ########################################################################################
-###### 2. Landcover class level metrics
+# 2. Landcover class level metrics
 ########################################################################################
 
 
-def _class_total_area(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_total_area(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
 
     class_areas = geo_graph.df["geometry"][
         geo_graph.df["class_label"] == class_value
@@ -203,7 +204,9 @@ def _class_total_area(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
     )
 
 
-def _class_avg_patch_area(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_avg_patch_area(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
 
     class_num_patches = geo_graph.get_metric(
         "num_patches", class_value=class_value
@@ -219,7 +222,9 @@ def _class_avg_patch_area(geo_graph: geograph.GeoGraph, class_value: int) -> Met
     )
 
 
-def _class_num_patches(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_num_patches(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
     return Metric(
         value=np.sum(geo_graph.df["class_label"] == class_value),
         name=f"num_patches_class={class_value}",
@@ -230,7 +235,7 @@ def _class_num_patches(geo_graph: geograph.GeoGraph, class_value: int) -> Metric
 
 
 def _class_proportion_of_landscape(
-    geo_graph: geograph.GeoGraph, class_value: int
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
 ) -> Metric:
 
     class_total_area = geo_graph.get_metric("total_area", class_value=class_value).value
@@ -245,7 +250,9 @@ def _class_proportion_of_landscape(
     )
 
 
-def _class_patch_density(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_patch_density(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
 
     class_num_patches = geo_graph.get_metric(
         "num_patches", class_value=class_value
@@ -262,7 +269,7 @@ def _class_patch_density(geo_graph: geograph.GeoGraph, class_value: int) -> Metr
 
 
 def _class_largest_patch_index(
-    geo_graph: geograph.GeoGraph, class_value: int
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
 ) -> Metric:
     """
     Return proportion of total landscape comprised by largest patch of given class.
@@ -270,7 +277,6 @@ def _class_largest_patch_index(
     Definition taken from:
         https://pylandstats.readthedocs.io/en/latest/landscape.html
     """
-
     total_area = geo_graph.get_metric("total_area").value
     class_areas = geo_graph.df["geometry"][
         geo_graph.df["class_label"] == class_value
@@ -278,7 +284,7 @@ def _class_largest_patch_index(
 
     description = (
         "Proportion of total landscape compriesed by largest patch of "
-        f"class {class_value} in the graph.",
+        f"class {class_value} in the graph."
     )
 
     return Metric(
@@ -290,7 +296,9 @@ def _class_largest_patch_index(
     )
 
 
-def _class_total_edge(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_total_edge(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
     # TODO: Implement option for not counting edges.
 
     class_perimeters = geo_graph.df["geometry"][
@@ -306,9 +314,12 @@ def _class_total_edge(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
     )
 
 
-def _class_edge_density(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_edge_density(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
     """
     Return total length of class edges for the given class.
+
     Note: Currently the boundary also counted towards the edge length.
 
     Definition taken from:
@@ -332,14 +343,15 @@ def _class_edge_density(geo_graph: geograph.GeoGraph, class_value: int) -> Metri
     )
 
 
-def _class_shape_index(geo_graph: geograph.GeoGraph, class_value: int) -> Metric:
+def _class_shape_index(
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
+) -> Metric:
     """
     Return shape index of given class.
 
     Definition taken from:
         https://pylandstats.readthedocs.io/en/latest/landscape.html
     """
-
     total_edge = geo_graph.get_metric("total_edge", class_value=class_value).value
     total_area = geo_graph.get_metric("total_area", class_value=class_value).value
 
@@ -359,7 +371,7 @@ def _class_shape_index(geo_graph: geograph.GeoGraph, class_value: int) -> Metric
 
 
 def _class_effective_mesh_size(
-    geo_graph: geograph.GeoGraph, class_value: int
+    geo_graph: geograph.GeoGraph, class_value: Union[int, str]
 ) -> Metric:
     """
     Return effective mesh size of given class.
@@ -367,7 +379,6 @@ def _class_effective_mesh_size(
     Definition taken from:
         https://pylandstats.readthedocs.io/en/latest/landscape.html
     """
-
     class_areas = geo_graph.df["geometry"][
         geo_graph.df["class_label"] == class_value
     ].area
@@ -402,8 +413,10 @@ CLASS_METRICS_DICT = {
 }
 
 ########################################################################################
-###### 3. Habitat componment level metrics
+# 3. Habitat componment level metrics
 ########################################################################################
+
+
 def _num_components(geo_graph: geograph.GeoGraph) -> Metric:
     return Metric(
         value=nx.number_connected_components(geo_graph.graph),
@@ -477,7 +490,7 @@ COMPONENT_METRICS_DICT = {
 
 
 ########################################################################################
-###### 4. Define access interface for GeoGraph
+# 4. Define access interface for GeoGraph
 ########################################################################################
 
 STANDARD_METRICS = ["num_components", "avg_patch_area", "total_area"]
@@ -486,11 +499,11 @@ STANDARD_METRICS = ["num_components", "avg_patch_area", "total_area"]
 def _get_metric(
     name: str,
     geo_graph: geograph.GeoGraph,
-    class_value: Optional[int] = None,
+    class_value: Union[int, str] = None,
     **metric_kwargs,
 ) -> Metric:
     """
-    Calculate selected metric for the given GeoGraph
+    Calculate selected metric for the given GeoGraph.
 
     Args:
         name (str): Name of the metric to compute
@@ -500,9 +513,8 @@ def _get_metric(
             is desired. Defaults to None.
 
     Returns:
-        Metric: The desired metric
+        Metric: The desired metric.
     """
-
     # Landscape level metrics
     if class_value is None:
         try:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ folium              # plotting maps
 ipyleaflet          # plotting ipywidget maps
 
 # interactive computing
-tqdm                # progress bars 
+tqdm                # progress bars
 
 # geospatial analysis requirements
 #  vector data
@@ -20,9 +20,8 @@ geopandas           # manipulating geospatial vector data
 shapely             # working with vector shapes
 rtree               # efficiently querying polygon data
 #  raster data
-rasterio            # opening and loading raster data
+rasterio==1.1.8     # opening and loading raster data
 xarray              # useful data structures
-
 
 # graph requirements
 networkx            # manipulating graph data

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ REQUIRED: List = [
     "geopandas",
     "shapely",
     "rtree",
-    "rasterio",
+    "rasterio==1.1.8",
     "xarray",
     "networkx",
 ]


### PR DESCRIPTION
This PR contains several miscellaneous features:

- Minor linting and type hinting improvements, including making type hints of class labels consistently Union[int, str].
- Pin Rasterio to 1.1.8
- New `_add_nodes` function in `geograph`.
- Fix the `merge_classes` function by detecting neighbouring polygons of the same class and merging them. Closes #44 
- Support for `barrier_classes` in `add_habitat`, with basic pathfinding functionality. This will only detect pathfinding problems if the polygon of the barrier node completely cuts the buffered polygon of the main node in half, preventing all access to the neighbouring polygon. This works by using Shapely's polygon difference function, see the comments for the actual algorithm.

The pathfinding code slows `add_habitat` down quite a bit, as might be expected, but it seems to make some difference to the final edge count:
![habitats](https://user-images.githubusercontent.com/13484097/118413554-d6809500-b697-11eb-9e9e-96ea918dff2c.jpg)

When this one is merged I will create the 0.0.2 release, upload it to PyPi and add it to Zenodo.
